### PR TITLE
Missing crucial libdnet setup instruction steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pip install scapy
 ```
 git clone https://github.com/dugsong/libdnet.git
 ./configure && make && make install
+cd python
+python setup.py install
 ```
 
 ## Sample Commands


### PR DESCRIPTION
Added few additional steps to the Installation section for libdnet setup. Missing python setup part of libdnet. The installation is broken if the steps are not executed.