### PR TITLE
KeyboardInterrupt exc. is misspelled

### DIFF
--- a/arpy.py
+++ b/arpy.py
@@ -151,7 +151,7 @@ def gw_poison():
     while True:
         try:
             scapy.send(gw,verbose=0,inter=1,loop=1)
-        except KeyboardInterupt:
+        except KeyboardInterrupt:
             print(bcolours.OKBLUE + '  [Warning] Stopping...' + bcolours.ENDC)
             sys.exit(3)
 


### PR DESCRIPTION
Line 154: Changed "KeyboardInterupt" to "KeyboardInterrupt"